### PR TITLE
Performance improvements

### DIFF
--- a/R/calculation_funs.R
+++ b/R/calculation_funs.R
@@ -1,3 +1,5 @@
+cat('Reading annual intensities from ../processed_data/Intensitymaster.csv. See Gostic et al. 2016 for details.')
+INTENSITY_DATA = read_csv('../processed-data/Intensitymatser.csv', show_col_types = F)
 
 get_p_infection_year = function(birth_year,
                                 observation_year, ## Year of data collection, which matters if observation_year is shortly after birth_year
@@ -10,11 +12,9 @@ get_p_infection_year = function(birth_year,
   ## OUTPUTS
   ##    - vector of 13 probabilities, the first representing the probability of first flu infection in the first year of life (age 0), the second representing the probability of first flu infection in the second year of life (age 1), and so on up to the 13th year of life (age 12)
   stopifnot(observation_year <= max_year)
-  cat('Reading annual intensities from ../processed_data/Intensitymaster.csv. See Gostic et al. 2016 for details.')
-  intensity_df = read_csv('../processed-data/Intensitymatser.csv', show_col_types = F)
   # Weighted attack rate = annual prob infection weighted by circulation intensity
-  weighted.attack.rate = baseline_annual_p_infection*(intensity_df$intensity)
-  names(weighted.attack.rate) = intensity_df$year
+  weighted.attack.rate = baseline_annual_p_infection*(INTENSITY_DATA$intensity)
+  names(weighted.attack.rate) = INTENSITY_DATA$year
   ################# Calculations ---------------
   possible_imprinting_years = birth_year:min(birth_year+12, observation_year) #Calendar years of first infection (ages 0-12)
   nn = length(possible_imprinting_years) # How many possible years of first infection? (should be 13)

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -1,0 +1,25 @@
+COUNTRY_NAMES = read_csv('../processed-data/country_names_long_short.csv', show_col_types = FALSE)
+THOMPSON_DATA = read_csv('../processed-data/Thompson_data.csv', show_col_types = FALSE)
+
+parse_region_names <- function(region){
+  ## Convert two-word region names for file import
+  if(tolower(region) == 'eastern mediterranean'){return('eastern_mediterranean')}
+  if(tolower(region) == 'western pacific'){return('western_pacific')}
+  if(tolower(region) == 'southeast asia'){return('southeast asia')}
+  ## else...
+  return(region)
+}
+
+get_region_data <- function() {
+
+  paths <- list.files('../raw-data/') %>%
+    lapply(function(region) tolower(parse_region_names(region))) %>%
+    lapply(function(region) list.files(sprintf('../raw-data/%s', region), full.names = TRUE)) %>%
+    flatten()
+  dfs = lapply(paths, function(path) read_csv(path, skip = 3, show_col_types = FALSE))
+  names(dfs) <- paths
+  dfs
+}
+
+REGION_DATA <- get_region_data()
+

--- a/R/script_caclulate_imprinting_probs.R
+++ b/R/script_caclulate_imprinting_probs.R
@@ -8,7 +8,6 @@ source('data_import_funs.R')
 
 ## NOTES:
 ## Currently, the maximum allowed observation_years value is 2017. I need to update the data to fix this.
-## I am not sure how to quiet all the weird tidyverse output to the console
 ## We may want to format these outputs as a long data frame instead of a list of matrices. The current format is a holdover from my previous work.
 
 ## Get probabilities for the United States in a single observation year

--- a/R/script_caclulate_imprinting_probs.R
+++ b/R/script_caclulate_imprinting_probs.R
@@ -1,3 +1,6 @@
+library(tidyverse)
+options(dplyr.summarise.inform = FALSE)
+
 ## Generate imprinting probabilities
 rm(list = ls())
 source('calculation_funs.R')


### PR DESCRIPTION
Performance improvements, mostly to get acquainted with the repo. Some other small changes. There's a foible that parse_region_names is imported with the read_csv code but we might be able to work that out over time.

Also there's a read_csv message for reading `../raw-data/southeast_asia/Southeast_Asia_1997-2004.csv`:

```
                                                                           
# A tibble: 3 × 5
    row   col expected           actual file 
  <int> <int> <chr>              <chr>  <chr>
1  4133    13 1/0/T/F/TRUE/FALSE 2      ""   
2  4134    13 1/0/T/F/TRUE/FALSE 2      ""   
3  4171    13 1/0/T/F/TRUE/FALSE 2      ""   

```
I don't think this is a problem with the code. This file just wasn't in the old examples.

Changes:
* Move `read_csv` out of functions.
* Add line to suppress messages from dplyr.
* Add tidyverse import.
* Remove some messages.
