### PR TITLE
Update intensity functionality

### DIFF
--- a/R/calculation_funs.R
+++ b/R/calculation_funs.R
@@ -64,7 +64,6 @@ get_imprinting_probabilities <- function(observation_years,  ## Year of data col
   birth_years = 1918:max_year
   infection_years = birth_years
   nn_birth_years = length(birth_years)
-  intensity_master = read_csv('../processed-data/Intensitymatser.csv', show_col_types = F)
   
   #Initialize matrices to store imprinting probabilities for each country and year
   #Rows - which country and year are we doing the reconstruction from the persepctive of?
@@ -79,7 +78,7 @@ get_imprinting_probabilities <- function(observation_years,  ## Year of data col
   for(this_country in countries){
     who_region = get_WHO_region(this_country)
     this_epi_data = get_country_cocirculation_data(this_country, max_year)
-    this_intensity_data = get_country_intensity_data(this_country, max_year, min_samples_processed_per_year = 50, intensity_master = intensity_master)
+    this_intensity_data = get_country_intensity_data(this_country, max_year, min_samples_processed_per_year = 50)
     
     #Extract and data from birth years of interest
     #These describe the fraction of circulating influenza viruses isolated in a given year that were of subtype H1N1 (type1), H2N2 (type2), or H3N2 (type3)

--- a/R/data_import_funs.R
+++ b/R/data_import_funs.R
@@ -135,7 +135,8 @@ get_regional_inputs_1997_to_present <- function(region, ## 'Americas', 'Europe',
                 n_A = n_H1N1+n_H3N2,
                 n_BYam = sum(BYAMAGATA, na.rm = T),
                 n_BVic = sum(BVICTORIA, na.rm = T),
-                n_B = n_BYam+n_BVic) %>% ungroup()
+                n_B = n_BYam+n_BVic,
+                n_processed = sum(SPEC_PROCESSED_NB, na.rm = T)) %>% ungroup()
   }) %>%
     bind_rows() ## Combine into a single data frame
   check_years(region_data$Year, max_year)
@@ -165,7 +166,8 @@ get_country_inputs_1997_to_present <- function(country,
                 n_A = n_H1N1+n_H3N2,
                 n_BYam = sum(BYAMAGATA, na.rm = T),
                 n_BVic = sum(BVICTORIA, na.rm = T),
-                n_B = n_BYam+n_BVic) %>%
+                n_B = n_BYam+n_BVic,
+                n_processed = sum(SPEC_PROCESSED_NB, na.rm = T)) %>%
       ungroup()
   }) %>%
     bind_rows() ## Combine into a single data frame
@@ -178,9 +180,9 @@ get_country_inputs_1997_to_present <- function(country,
 }
 
 
-get_country_data <- function(country,
+get_country_cocirculation_data <- function(country,
                              max_year,
-                             min_samples_per_year = 30 ## If not enough observations available, default to regional data
+                             min_fluA_positive_samples_per_year = 30 ## If not enough observations available, default to regional data
                              ){
   ## Input - country name
   ## Output - Data frame containing:
@@ -195,7 +197,7 @@ get_country_data <- function(country,
   template = get_template_data()
   ## Get country data, and only keep years in which there are enough samples to meet the threshold
   country_data = get_country_inputs_1997_to_present(country, max_year) %>%
-    dplyr::filter(n_A >= min_samples_per_year) %>%
+    dplyr::filter(n_A >= min_fluA_positive_samples_per_year) %>%
     mutate(data_from = paste0('country: ', country))
   ## Get regional data for years that don't meet the threshold
   region_data = get_regional_inputs_1997_to_present(get_WHO_region(country), max_year) %>%
@@ -227,6 +229,46 @@ get_country_data <- function(country,
     t()
   colnames(output_matrix) = output_matrix['year',]
   return(output_matrix)    
+}
+
+
+get_country_intensity_data <- function(country,
+                                       max_year,
+                                       min_samples_processed_per_year = 30, ## If not enough observations available, default to regional data
+                                       intensity_master
+){
+  ## Input - country name
+  ## Output - Data frame containing:
+  ##  * year: 1918:max_year
+  ##  * intensity: [fraction of processed samples positive for flu A]/[mean fraction of processed samples positive for flu A]
+  
+  pre_1997_intensity = intensity_master %>% dplyr::filter(year <= 1997)
+  ## Get country data, and only keep years in which there are enough samples to meet the threshold
+  country_data = get_country_inputs_1997_to_present(country, max_year) %>%
+    dplyr::filter(n_A >= min_samples_processed_per_year) %>%
+    mutate(data_from = paste0('country: ', country))
+  ## Get regional data for years that don't meet the threshold
+  region_data = get_regional_inputs_1997_to_present(get_WHO_region(country), max_year) %>%
+    dplyr::filter(!(Year %in% country_data$Year))
+  
+  ## Calculate the proportions of each subtype from counts,
+  ## And reformat to match the template columns
+  formatted_data = bind_rows(region_data,
+                             country_data) %>%
+    mutate(raw_intensity = n_A/n_processed,
+           intensity = raw_intensity/mean(raw_intensity, na.rm = T), ## Define intensity relative to the mean
+           intensity = pmin(intensity, 2.5)) %>% ## Max intensity is 2.5
+    rename(year = Year)%>%
+    select(year, intensity)
+
+  
+  ## Combine with the template data for pre-1977 years
+  full_outputs = bind_rows(pre_1997_intensity,
+                           formatted_data)
+  # ggplot(full_outputs) + geom_point(aes(x = year, y = intensity))
+  check_years(years = full_outputs$year, max_year = max_year)
+  ## Format as a matrix whose column names are years
+  return(full_outputs)    
 }
 
 

--- a/R/data_import_funs.R
+++ b/R/data_import_funs.R
@@ -234,15 +234,14 @@ get_country_cocirculation_data <- function(country,
 
 get_country_intensity_data <- function(country,
                                        max_year,
-                                       min_samples_processed_per_year = 30, ## If not enough observations available, default to regional data
-                                       intensity_master
+                                       min_samples_processed_per_year = 30 ## If not enough observations available, default to regional data
 ){
   ## Input - country name
   ## Output - Data frame containing:
   ##  * year: 1918:max_year
   ##  * intensity: [fraction of processed samples positive for flu A]/[mean fraction of processed samples positive for flu A]
   
-  pre_1997_intensity = intensity_master %>% dplyr::filter(year <= 1997)
+  pre_1997_intensity = INTENSITY_MASTER %>% dplyr::filter(year <= 1997)
   ## Get country data, and only keep years in which there are enough samples to meet the threshold
   country_data = get_country_inputs_1997_to_present(country, max_year) %>%
     dplyr::filter(n_A >= min_samples_processed_per_year) %>%


### PR DESCRIPTION
Intensities quantify the intensity of influenza A circulation in a given country and year, which scales the probability that a first  infection occurs in that year. They are equal to [fraction of tested specimens positive for flu A]/[mean fraction of tested specimens positive for flu A].

Previously, intensities were pulled from a .csv file that was only complete up to 2017.

**Changes:**

* Intensities for 1997-present are now calculated using data from WHO flu mart on the total number of specimens tested, and positive for flu A.
* Intensities from 1997-present are country-specific, or region-specific if sample size is insufficient.
* For years 1918-1996, intensities are still pulled from the master .csv, because we lack country-specific data for those years.