### PR TITLE
Explicitly specified column types 

### DIFF
--- a/R/calculation_funs.R
+++ b/R/calculation_funs.R
@@ -1,5 +1,5 @@
 cat('Reading annual intensities from ../processed_data/Intensitymaster.csv. See Gostic et al. 2016 for details.')
-INTENSITY_DATA = read_csv('../processed-data/Intensitymatser.csv', show_col_types = F)
+INTENSITY_DATA = read_csv('../processed-data/Intensitymatser.csv', col_types = 'id')
 
 get_p_infection_year = function(birth_year,
                                 observation_year, ## Year of data collection, which matters if observation_year is shortly after birth_year

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -1,6 +1,6 @@
-COUNTRY_NAMES = read_csv('../processed-data/country_names_long_short.csv', show_col_types = FALSE)
-THOMPSON_DATA = read_csv('../processed-data/Thompson_data.csv', show_col_types = FALSE)
-INTENSITY_MASTER = read_csv('../processed-data/Intensitymatser.csv', show_col_types = FALSE)
+COUNTRY_NAMES = read_csv('../processed-data/country_names_long_short.csv', col_types = 'ccc')
+THOMPSON_DATA = read_csv('../processed-data/Thompson_data.csv', col_types = 'iiiiii')
+INTENSITY_MASTER = read_csv('../processed-data/Intensitymatser.csv', col_types = 'id')
 
 parse_region_names <- function(region){
   ## Convert two-word region names for file import


### PR DESCRIPTION
Instead of instead of using the show_col_types =F option in `read_csv()` to quiet messages, I explicitly specified column types. This should make the code more robust to older readr versions.