### PR TITLE
Fix NA issue

### DIFF
--- a/R/calculation_funs.R
+++ b/R/calculation_funs.R
@@ -14,8 +14,8 @@ get_p_infection_year = function(birth_year,
   ##    - vector of 13 probabilities, the first representing the probability of first flu infection in the first year of life (age 0), the second representing the probability of first flu infection in the second year of life (age 1), and so on up to the 13th year of life (age 12)
   stopifnot(observation_year <= max_year)
   # Weighted attack rate = annual prob infection weighted by circulation intensity
-  weighted.attack.rate = baseline_annual_p_infection*(INTENSITY_DATA$intensity)
-  names(weighted.attack.rate) = INTENSITY_DATA$year
+  weighted.attack.rate = baseline_annual_p_infection*(intensity_df$intensity)
+  names(weighted.attack.rate) = intensity_df$year
   ################# Calculations ---------------
   possible_imprinting_years = birth_year:min(birth_year+12, observation_year) #Calendar years of first infection (ages 0-12)
   nn = length(possible_imprinting_years) # How many possible years of first infection? (should be 13)
@@ -89,6 +89,7 @@ get_imprinting_probabilities <- function(observation_years,  ## Year of data col
     who_region = get_WHO_region(this_country)
     this_epi_data = get_country_cocirculation_data(this_country, max_year)
     this_intensity_data = get_country_intensity_data(this_country, max_year, min_samples_processed_per_year = 50)
+    stopifnot(!any(is.na(this_intensity_data$intensity)))
     
     #Extract and data from birth years of interest
     #These describe the fraction of circulating influenza viruses isolated in a given year that were of subtype H1N1 (type1), H2N2 (type2), or H3N2 (type3)

--- a/R/tests.R
+++ b/R/tests.R
@@ -104,3 +104,18 @@ test_that("Range of years returned equals range of years passed.", {
 
 })
 
+
+
+test_that("Numeric (non-NA) probabilities are returned for post-2017 observation years.", {
+  library(tidyverse)
+  source('calculation_funs.R')
+  source('data_import_funs.R')
+  
+  obs_year = 2022
+  min_year = 1918
+  
+  probs = get_imprinting_probabilities(observation_years = obs_year, countries = c('United States'))
+  
+  expect_false(any(is.na(probs$imprinting_prob)))
+})
+

--- a/R/tests.R
+++ b/R/tests.R
@@ -9,9 +9,9 @@ test_that("Observation year less than 13 years from birth year gives known-good 
   INTENSITY_DATA = get_country_intensity_data("United States", 2010, min_samples_processed_per_year = 50)
 
   # Birth Year 2007
-  expect_equal(get_p_infection_year(2007, 2010, 0.28, 2010, INTENSITY_DATA), c(0.42098152, 0.16439171, 0.29023874, 0.03097275))
+  expect_equal(get_p_infection_year(2007, 2010, 0.28, 2010, INTENSITY_DATA), c(0.19899714, 0.18616278, 0.43038805, 0.03884563))
   # Birth Year 2010
-  expect_equal(get_p_infection_year(2010, 2010, 0.28, 2010, INTENSITY_DATA), c(0.2490017), tolerance = 0.000001)
+  expect_equal(get_p_infection_year(2010, 2010, 0.28, 2010, INTENSITY_DATA), c(0.2106002), tolerance = 0.000001)
 
 })
 
@@ -24,10 +24,10 @@ test_that("Observation year greater than 13 years from birth year gives known-go
   INTENSITY_DATA = get_country_intensity_data("United States", 2010, min_samples_processed_per_year = 50)
 
   # Birth Year 1995
-  expect_equal(get_p_infection_year(1995, 2010, 0.28, 2010, INTENSITY_DATA), c(0.224672982, 0.243177207, 0.076945392, 0.008765326, 0.073416962, 0.090385447, 0.040737142, 0.127933613, 0.019213806, 0.030645188, 0.020023422, 0.010588820, 0.014100647))
+  expect_equal(get_p_infection_year(1995, 2010, 0.28, 2010, INTENSITY_DATA), c(0.22467298, 0.24317721, 0.07694539, 0.02963517, 0.11150953, 0.05575555, 0.03564507, 0.04825983, 0.06960915, 0.01243207, 0.02032434, 0.01586563, 0.01117729))
 
   # Birth Year 1998
-  expect_equal(get_p_infection_year(1998, 2010, 0.28, 2010, INTENSITY_DATA), c(0.019255801, 0.161283500, 0.198560127, 0.089491975, 0.281046509, 0.042209182, 0.067321817, 0.043987758, 0.023261680, 0.030976516, 0.012096213, 0.021356245, 0.002279026))
+  expect_equal(get_p_infection_year(1998, 2010, 0.28, 2010, INTENSITY_DATA), c(0.065103001, 0.244965840, 0.122484638, 0.078305628, 0.106017928, 0.152918439, 0.027310965, 0.044648818, 0.034853868, 0.024554432, 0.022970789, 0.053105959, 0.004793197))
 })
 
 test_that("Number of probabilities are same as number of years in input.", {


### PR DESCRIPTION
Fixed a bug that was causing NA outputs for observation years greater than 2017.

Fixes issue #7 

1. The `get_p_infection_year` function now correctly uses the intensity_df, not INTENSITY_MASTER to calculate annual circulation intensitites. INTENSITY_MASTER is a template that only contains data through 2017. intensity_df is created within `get_imprinting_probabilities`, and it replaces generic entries in intensity_master with country or region-specific data for years in which these data are available (1997:present).

2. Added a test to check that the function returns non-NA probabilities, even for observation years after 2017.