### PR TITLE
Check who data

### DIFF
--- a/R/Check_WHO_data.Rmd
+++ b/R/Check_WHO_data.Rmd
@@ -1,0 +1,94 @@
+---
+title: "Check WHO data"
+output: pdf_document
+---
+
+For 1997:present, we calculate the raw circulation intensity as the fraction of influenza samples processed that are positive for influenza A. We use country-specific data reported in WHO Flu Net, except if there are <50 samples processed within-country, we substitute regional data for that year.
+
+$\text{raw intensity} = \frac{n_A}{n_{processed}}$
+
+$n_A$ and $n_{processed}$ data values are reported in the raw data on WHO flu net.
+
+We then calculate the relative intensity of influenza A ciruclation in each year $y$ as $\frac{\text{raw intensity}_y}{\text{mean}(\text{raw intensity}_y)}$. We use the relative intensity to scale the annual probability of primary infection, so that so that the probability of imprinting in a year with higher-than average influenza A circulation is slightly higher than baseline.
+
+
+**Problem**
+
+The total number of specimens processed (n_processed) should always be greater than or equal to the number of infelunza A positive specimens in a given country and year.
+
+However, code testing revealed that in some cases (e.g. Germany, 1997), reported $n_{processed}$ values are less than $n_A$, the number of flu-A positive specimens.
+
+The purpose of this notebook is to check how often the n_processed column violates quality checks, and to decide how to handle exceptions.
+
+**Testing plan**
+
+For each country and year, check that:
+
+$n_{processed} \geq n_A+n_B$
+
+```{r}
+library(tidyverse)
+source('load_data.R')
+source('data_import_funs.R')
+```
+
+```{r}
+check_one_country = function(country){
+  max_year=2022
+  min_samples_processed_per_year = 30 ## If not enough observations available, default to regional data
+  
+  get_country_inputs_1997_to_present(country, max_year) %>%
+    #dplyr::filter(n_processed >= min_samples_processed_per_year) %>%
+    mutate(data_from = paste0('country: ', country)) %>%
+    mutate(check = n_processed >= n_A+n_B) %>% ## Implement check
+    select(Country, Year, n_H1N1, n_H3N2, n_A, n_B, n_processed, check) %>%
+    dplyr::filter(check == FALSE) ## Retun rows that fail check
+}
+```
+
+```{r message=FALSE}
+## Appply the test to all countries
+all_failures = lapply(show_available_countries()$country, FUN = check_one_country) %>%
+  bind_rows()
+```
+
+## Overall, there are 165 failures
+```{r}
+all_failures
+```
+
+## We eliminate most of the failures if we require >= 30 samples processed per year
+```{r message=FALSE}
+all_failures %>%
+  filter(n_processed > 30)
+```
+
+## We eliminate most of the failures if we require >= 50 samples processed per year
+```{r message=FALSE}
+all_failures %>%
+  filter(n_processed > 50)
+```
+
+## Check if the problem persists at the regional level
+```{r}
+check_one_region = function(region){
+  max_year=2022
+  
+get_regional_inputs_1997_to_present(region, max_year) %>%
+    mutate(check = n_processed >= n_A+n_B) %>% ## Implement check
+    select(WHOREGION, Year, n_H1N1, n_H3N2, n_A, n_B, n_processed, check) %>%
+    dplyr::filter(check == FALSE) ## Retun rows that fail check
+}
+```
+
+## There are a few years in the eastern mediterranean region that lack sufficient sample numbers and fail quality checks
+```{r}
+lapply(show_available_regions()$region %>% parse_region_names(), check_one_region)
+```
+
+
+## Overall plan to implement quality checks in intensity calculation pipeline:
+
+1. If >50 samples processed, and passes quality check (n_processed >= (n_A + n_B)), use country-specific data
+2. If >50 samples processed, and passes quality check, substitute region-specific data
+3. Else, if regional and country-specific data don't meet quality standards, default to the null value of intensity = 1

--- a/R/calculation_funs.R
+++ b/R/calculation_funs.R
@@ -14,8 +14,8 @@ get_p_infection_year = function(birth_year,
   ##    - vector of 13 probabilities, the first representing the probability of first flu infection in the first year of life (age 0), the second representing the probability of first flu infection in the second year of life (age 1), and so on up to the 13th year of life (age 12)
   stopifnot(observation_year <= max_year)
   # Weighted attack rate = annual prob infection weighted by circulation intensity
-  weighted.attack.rate = baseline_annual_p_infection*(INTENSITY_DATA$intensity)
-  names(weighted.attack.rate) = INTENSITY_DATA$year
+  weighted.attack.rate = baseline_annual_p_infection*(intensity_df$intensity)
+  names(weighted.attack.rate) = intensity_df$year
   ################# Calculations ---------------
   possible_imprinting_years = birth_year:min(birth_year+12, observation_year) #Calendar years of first infection (ages 0-12)
   nn = length(possible_imprinting_years) # How many possible years of first infection? (should be 13)
@@ -89,6 +89,7 @@ get_imprinting_probabilities <- function(observation_years,  ## Year of data col
     who_region = get_WHO_region(this_country)
     this_epi_data = get_country_cocirculation_data(this_country, max_year)
     this_intensity_data = get_country_intensity_data(this_country, max_year, min_samples_processed_per_year = 50)
+    stopifnot(!any(is.na(this_intensity_data$intensity)))
     
     #Extract and data from birth years of interest
     #These describe the fraction of circulating influenza viruses isolated in a given year that were of subtype H1N1 (type1), H2N2 (type2), or H3N2 (type3)

--- a/R/calculation_funs.R
+++ b/R/calculation_funs.R
@@ -111,7 +111,8 @@ get_imprinting_probabilities <- function(observation_years,  ## Year of data col
       n_valid_birth_years = observation_years[jj]-1918+1
       for(ii in 1:n_valid_birth_years){ #for all birth years elapsed up to the observation year
         n_infection_years = min(12, observation_years[jj]-birth_years[ii]) # first infections can occur up to age 12, or up until the current year, whichever comes first
-        inf.probs = get_p_infection_year(birth_years[ii], observation_years[jj], 
+        inf.probs = get_p_infection_year(birth_year = birth_years[ii], 
+                                         observation_year = observation_years[jj], 
                                          baseline_annual_p_infection = 0.28, 
                                          max_year = max_year,
                                          intensity_df = this_intensity_data) # Get vector of year-specific probs of first infection

--- a/R/script_caclulate_imprinting_probs.R
+++ b/R/script_caclulate_imprinting_probs.R
@@ -4,6 +4,7 @@ library(tidyverse)
 options(dplyr.summarise.inform = FALSE)
 source('calculation_funs.R')
 source('data_import_funs.R')
+source('plotting_funs.R')
 
 
 ## Get probabilities for the United States in a single observation year
@@ -19,19 +20,28 @@ get_imprinting_probabilities(observation_years = 2015,
                              countries = c('Mexico'))
 
 get_imprinting_probabilities(observation_years = 2015, 
-                             countries = c('Germany'))
+                             countries = c('Germany'))%>%
+  plot_one_country_year()
+
 
 get_imprinting_probabilities(observation_years = 2015, 
-                             countries = c('Egypt'))
+                             countries = c('Egypt'))%>%
+  plot_one_country_year()
+
 
 get_imprinting_probabilities(observation_years = 2015, 
-                             countries = c('Kenya'))
+                             countries = c('Kenya'))%>%
+  plot_one_country_year()
+
 
 get_imprinting_probabilities(observation_years = 2015, 
-                             countries = c('Australia'))
+                             countries = c('Australia'))%>%
+  plot_one_country_year()
+
 
 get_imprinting_probabilities(observation_years = 2015, 
-                             countries = c('Cambodia'))
+                             countries = c('Cambodia')) %>%
+  plot_one_country_year()
 
 ## Get probabilities for the many countries in one observation year
 get_imprinting_probabilities(observation_years = 2015, 
@@ -42,7 +52,8 @@ get_imprinting_probabilities(observation_years = 2015:2017,
                              countries = c('Argentina', 'United Kingdom', 'Canada', 'Israel'))
 
 get_imprinting_probabilities(observation_years = c(2007, 2010, 2022), 
-                             countries = c('Venezuela', 'Laos', 'Lithuania'))
+                             countries = c('Venezuela', 'Laos', 'Lithuania')) %>%
+  plot_many_country_years()
 
 
 

--- a/R/tests.R
+++ b/R/tests.R
@@ -119,3 +119,21 @@ test_that("Numeric (non-NA) probabilities are returned for post-2017 observation
   expect_false(any(is.na(probs$imprinting_prob)))
 })
 
+test_that("Countries with low-quality intensity data return appropriate intensity values.", {
+
+library(tidyverse)
+source('calculation_funs.R')
+source('data_import_funs.R')
+
+intensities_Germany = get_country_intensity_data(country = c('Germany'), 
+                                                 max_year = 2022, 
+                                                 min_samples_processed_per_year = 50)
+intensities_Iraq = get_country_intensity_data(country = c('Iraq'), 
+                                                 max_year = 2022, 
+                                                 min_samples_processed_per_year = 50)
+
+expect_false(any(is.na(intensities_Germany$intensity)))
+expect_false(any(is.na(intensities_Iraq$intensity)))
+expect_true(all(intensities_Germany$intensity >= -2.5 & intensities_Germany$intensity <= 2.5))
+expect_true(all(intensities_Iraq$intensity >= -2.5 & intensities_Iraq$intensity <= 2.5))
+})

--- a/R/tests.R
+++ b/R/tests.R
@@ -104,3 +104,18 @@ test_that("Range of years returned equals range of years passed.", {
 
 })
 
+
+
+test_that("Numeric (non-NA) probabilities are returned for post-2017 observation years.", {
+  library(tidyverse)
+  source('calculation_funs.R')
+  source('data_import_funs.R')
+  
+  obs_year = 2022
+  min_year = 1918
+  
+  probs = get_imprinting_probabilities(observation_years = obs_year, countries = c('United States'))
+  
+  expect_false(any(is.na(probs$imprinting_prob)))
+})
+

--- a/R/tests.R
+++ b/R/tests.R
@@ -9,9 +9,9 @@ test_that("Observation year less than 13 years from birth year gives known-good 
   INTENSITY_DATA = get_country_intensity_data("United States", 2010, min_samples_processed_per_year = 50)
 
   # Birth Year 2007
-  expect_equal(get_p_infection_year(2007, 2010, 0.28, 2010, INTENSITY_DATA), c(0.42098152, 0.16439171, 0.29023874, 0.03097275))
+  expect_equal(get_p_infection_year(2007, 2010, 0.28, 2010, INTENSITY_DATA), c(0.19899714, 0.18616278, 0.43038805, 0.03884563))
   # Birth Year 2010
-  expect_equal(get_p_infection_year(2010, 2010, 0.28, 2010, INTENSITY_DATA), c(0.2490017), tolerance = 0.000001)
+  expect_equal(get_p_infection_year(2010, 2010, 0.28, 2010, INTENSITY_DATA), c(0.2106002), tolerance = 0.000001)
 
 })
 
@@ -24,10 +24,10 @@ test_that("Observation year greater than 13 years from birth year gives known-go
   INTENSITY_DATA = get_country_intensity_data("United States", 2010, min_samples_processed_per_year = 50)
 
   # Birth Year 1995
-  expect_equal(get_p_infection_year(1995, 2010, 0.28, 2010, INTENSITY_DATA), c(0.224672982, 0.243177207, 0.076945392, 0.008765326, 0.073416962, 0.090385447, 0.040737142, 0.127933613, 0.019213806, 0.030645188, 0.020023422, 0.010588820, 0.014100647))
+  expect_equal(get_p_infection_year(1995, 2010, 0.28, 2010, INTENSITY_DATA), c(0.22467298, 0.24317721, 0.07694539, 0.02963517, 0.11150953, 0.05575555, 0.03564507, 0.04825983, 0.06960915, 0.01243207, 0.02032434, 0.01586563, 0.01117729))
 
   # Birth Year 1998
-  expect_equal(get_p_infection_year(1998, 2010, 0.28, 2010, INTENSITY_DATA), c(0.019255801, 0.161283500, 0.198560127, 0.089491975, 0.281046509, 0.042209182, 0.067321817, 0.043987758, 0.023261680, 0.030976516, 0.012096213, 0.021356245, 0.002279026))
+  expect_equal(get_p_infection_year(1998, 2010, 0.28, 2010, INTENSITY_DATA), c(0.065103001, 0.244965840, 0.122484638, 0.078305628, 0.106017928, 0.152918439, 0.027310965, 0.044648818, 0.034853868, 0.024554432, 0.022970789, 0.053105959, 0.004793197))
 })
 
 test_that("Number of probabilities are same as number of years in input.", {

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(Reconstructions)
+
+test_check("Reconstructions")


### PR DESCRIPTION
Testing revealed that intensity values, which scale the annual probability of primary infection, were sometimes NaN.

NaN estimates were the result of poor data quality. Intensity values are based on the test-positivity rate for influenza A in a given country and year, i.e. the number of flu A positive tests divided by the total number of tests.

In some countries and years, the reported total number of tests was 0, or was less than the number of positive tests reported.

This branch:

1. Includes a notebook, `Check_WHO_data.Rmd`, that explores and documents these issues and proposes a new quality control strategy.
2. Implements the new quality control strategy in the function `get_country_intensity_data`.
3. Develops new tests and edits the runbook to safeguard against future data quality issues of this kind.