### PR TITLE
1996 bug fix

### DIFF
--- a/R/data_import_funs.R
+++ b/R/data_import_funs.R
@@ -297,6 +297,8 @@ get_country_cocirculation_data <- function(country,
                                            min_samples = 30) {
   check_max_year(max_year)
   template <- get_template_data()
+  
+  if(max_year >= 1996){
   ## Get country data, and only keep years in which there are enough samples to meet the threshold
   country_data <- get_country_inputs_1997_to_present(country, max_year) %>%
     dplyr::filter(n_A >= min_samples) %>%
@@ -330,7 +332,12 @@ get_country_cocirculation_data <- function(country,
     template,
     formatted_data
   )
-  check_years(years = full_outputs$year, max_year = max_year)
+  }else{
+    full_outputs <- template %>%
+      dplyr::filter(year <= max_year)
+  }
+  
+  stopifnot(1918:max_year %in% full_outputs$year)
   test_rowsums_group(full_outputs$group1, group2 = full_outputs$group2)
   test_rowsums_subtype(full_outputs$`A/H1N1`, full_outputs$`A/H2N2`, full_outputs$`A/H3N2`)
   ## Format as a matrix whose column names are years
@@ -365,6 +372,8 @@ get_country_intensity_data <- function(country,
   check_max_year(max_year)
   pre_1997_intensity <- INTENSITY_DATA %>% dplyr::filter(year <= 1997)
   ## Get country data, and only keep years in which there are enough samples to meet the threshold
+  
+  if(max_year > 1996){
   country_data <- get_country_inputs_1997_to_present(country, max_year) %>%
     dplyr::filter(n_processed >= min_specimens) %>% ## Exclude country-years that don't meet the minimum sample size
     mutate(quality_check = n_processed >= (n_A + n_B)) %>%
@@ -405,8 +414,11 @@ get_country_intensity_data <- function(country,
     pre_1997_intensity,
     formatted_data
   )
-  # ggplot(full_outputs) + geom_point(aes(x = year, y = intensity))
-  check_years(years = full_outputs$year, max_year = max_year)
+  }else{
+    full_outputs = pre_1997_intensity %>%
+      dplyr::filter(year <= max_year)
+  }
+  stopifnot(1918:max_year %in% full_outputs$year)
   ## Format as a matrix whose column names are years
   return(full_outputs)
 }

--- a/tests/testthat/test-imprinting-probabilities.R
+++ b/tests/testthat/test-imprinting-probabilities.R
@@ -13,3 +13,9 @@ test_that("Range of years returned equals range of years passed.", {
   expect_equal(max(probs$birth_year), obs_year)
   expect_equal(min(probs$birth_year), min_year)
 })
+
+test_that("Observation year prior to 1996 returns known, valid probabilities", {
+  probs <- get_imprinting_probabilities(observation_years = 1919, countries = 'Aruba', df_format = 'long')
+  
+  expect_equal(probs$imprinting_prob, c(0.70, 0.91, 0.00, 0.00, 0.00, 0.00, 0.30, 0.09), tolerance = 0.01)
+})


### PR DESCRIPTION
* Previously get_imprinting_probabilities() threw an error if the observation year was between 1918 and 1996, due to a null data import issue.
* I added if statements to 'get_country_cocirculation_data()' and 'get_country_intensity_data()' to fix the bug.
* I added a test to check for this bug in the future.