### PR TITLE
Remove lazydata option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ Authors@R:
 Description: Reconstruct birth-year specific probabilities of immune imprinting to influenza A, using the methods of Gostic et al. 2016 (DOI: 10.1126/science.aag1322). Plot, save, or export the calculated probabilities for use in your own research. By default, the package calculates subtype-specific imprinting probabilities, but with user-provided frequency data, it is possible to calculate probabilities for arbitrary kinds of primary exposure to influenza A, including primary vaccination and exposure to specific clades, strains, etc.
 License: MIT + file LICENSE
 Encoding: UTF-8
-LazyData: true
 Imports:
     dplyr (>= 1.0.9),
     tidyr (>= 1.2.0),


### PR DESCRIPTION
According to https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file: 

"The ‘LazyData’ logical field controls whether the R datasets use lazy-loading. A ‘LazyLoad’ field was used in versions prior to 2.14.0, but now is ignored. "

Should be safe to merge. Already discussed with @kgostic 