### PR TITLE
Alternative solution to example performance

### DIFF
--- a/R/plotting_funs.R
+++ b/R/plotting_funs.R
@@ -100,7 +100,7 @@ plot_one_country_year <- function(imprinting_df,
 #' @examples
 #' # Note: May be resource intensive.
 #' # imprinting_df <- get_imprinting_probabilities(
-#' # observation_years = c(1997, 1998),
+#' # observation_years = c(1920, 1921),
 #' # countries = c("Oman", "Indonesia")
 #' # )
 #' # plot_many_country_years(imprinting_df)

--- a/R/plotting_funs.R
+++ b/R/plotting_funs.R
@@ -98,12 +98,11 @@ plot_one_country_year <- function(imprinting_df,
 #' @param imprinting_df A long data frame of imprinted probabilities output by [get_imprinting_probabilities()]. Up to five countries and an arbitrary span of years can be plotted.
 #'
 #' @examples
-#' # Note: May be resource intensive.
-#' # imprinting_df <- get_imprinting_probabilities(
-#' # observation_years = c(1920, 1921),
-#' # countries = c("Oman", "Indonesia")
-#' # )
-#' # plot_many_country_years(imprinting_df)
+#' imprinting_df <- get_imprinting_probabilities(
+#'   observation_years = c(1920, 1921),
+#'   countries = c("Oman", "Indonesia")
+#' )
+#' plot_many_country_years(imprinting_df)
 #' @export
 plot_many_country_years <- function(imprinting_df) {
   # bind column name variables to function to avoid nonstandard evaluation issues in CRAN

--- a/man/plot_many_country_years.Rd
+++ b/man/plot_many_country_years.Rd
@@ -24,7 +24,7 @@ time.
 }
 \examples{
 imprinting_df <- get_imprinting_probabilities(
-  observation_years = c(1997, 1998),
+  observation_years = c(1920, 1921),
   countries = c("Oman", "Indonesia")
 )
 plot_many_country_years(imprinting_df)


### PR DESCRIPTION
Change example years to 1920-21 to improve performance in `plot_many_country_years`. This may be unnecessary because documentation also needed to be rebuilt with `devtools::document()` but it should improve our chances if '97-'98 is too slow on the test machine.