### PR TITLE
Example fix for Windows test at CRAN

### DIFF
--- a/R/plotting_funs.R
+++ b/R/plotting_funs.R
@@ -11,14 +11,14 @@
 #' @examples
 #' # Generate imprinting probabilities for one country and year
 #' imprinting_df <- get_imprinting_probabilities(
-#'   observation_years = 2022,
+#'   observation_years = 1920,
 #'   countries = "Aruba"
 #' )
 #' plot_one_country_year(imprinting_df)
 #'
 #' # If we generate probabilities for more than one country and year,
 #' imprinting_df <- get_imprinting_probabilities(
-#'   observation_years = c(1997, 2001),
+#'   observation_years = c(1922, 1925),
 #'   countries = c(
 #'     "Algeria",
 #'     "South Africa"
@@ -32,7 +32,7 @@
 #' # imprinting_df).
 #' plot_one_country_year(imprinting_df,
 #'   country = "South Africa",
-#'   year = 2001
+#'   year = 1925
 #' )
 #'
 #' @export


### PR DESCRIPTION
Plot earlier years for single year example to improve performance. The single year plot example is failing on Windows for the CRAN test. (Previous fix was for multiple years, and on Debian.)